### PR TITLE
Require coffee-script/register for coffee 1.7.x.

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ Environmental variables
  - PORT
 */
 
-require("coffee-script");
+require("coffee-script/register");
 app = require("./controllers/host.coffee");
 http = require("http");
 port = process.env.PORT || 2222;


### PR DESCRIPTION
In coffee-script 1.7, the default module no longer registers a require handler due to require.extensions [being deprecated](http://nodejs.org/api/globals.html#globals_require_extensions).

Thankfully, we can just require coffee-script/register instead, and it restores this behavior (by using the deprecated API… ehhhh).
