### PR TITLE
Bundle css files with compiled stylus.

### DIFF
--- a/assets/css/main.styl
+++ b/assets/css/main.styl
@@ -1,3 +1,6 @@
+//= require normalize
+//= require vex
+//= require vex-theme-os
 @import "variables"
 
 body

--- a/assets/css/variables.styl
+++ b/assets/css/variables.styl
@@ -13,3 +13,6 @@ cornucopia-color = #F2A138
 hinderlands-color = #8EB365
 darkages-color = #804020
 guilds-color = #F59DC0
+
+.csso-complains-with-empty-files
+  color: inherit

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
       "passport": "0.1.x",
       "passport-local": "0.1.x",
       "mongoose": "3.8.x",
-      "async": "0.2.x"
+      "async": "0.2.x",
+      "csso": "1.3.x",
+      "uglify-js": "2.4.x"
    }
 }

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -5,9 +5,6 @@ html
       meta(http-equiv="X-UA-Compatible", content="IE=edge,chrome=1")
       meta(name="viewport", content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no")
       link(href='http://fonts.googleapis.com/css?family=Alegreya+Sans+SC' rel='stylesheet' type='text/css')
-      != css("normalize")
-      != css("vex")
-      != css("vex-theme-os")
       != css("main")
       != js("site")
 


### PR DESCRIPTION
Instead of calling `css()` from the layout multiple times, you can just include the `//= require` directives in stylus. This way, in production, everything gets all bundled up nice and tidy.

Also, csso and uglify-js are required for connect-assets@3.0.0-beta1 in production. I think I might add those as dependencies before v3 gets shipped… but until then, you’ll have to include them.

Also, apparently csso doesn’t like compiling empty files. Since connect-assets precompiles everything in your assets tree by default in production, variables.styl ends up throwing an error. You could specify a precompilation list to connect-assets, but I just added a style rule to variables.styl instead. Let me know if you’d like me to change it.
