### PR TITLE
Allow cross-site usage of the options cookie

### DIFF
--- a/src/settings/settings-manager.ts
+++ b/src/settings/settings-manager.ts
@@ -12,5 +12,5 @@ export function loadSettings(): Settings {
 }
 
 export function saveSettings(settings: Settings) {
-  Cookie.set("options", settings, {expires: 365});
+  Cookie.set("options", settings, {expires: 365, sameSite: "none"});
 }


### PR DESCRIPTION
The [SameSite cookie](https://web.dev/samesite-cookies-explained/) setting (which now defaults to `lax` in Chrome) limits access of the `options` cookie.
This breaks [command.games](https://github.com/davidtorosyan/command.games), which depends on this cookie. 
This change sets `sameSite` to `none`, which should fix the plugin.

See issue #58.